### PR TITLE
Optimized clustering-vt tiles generation.

### DIFF
--- a/analyser/rules_specifications/BA_way_not_part_relation.yaml
+++ b/analyser/rules_specifications/BA_way_not_part_relation.yaml
@@ -20,8 +20,9 @@ QUERY:
               properties:
                 - way_id: !variable osm_id
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/addr_housenumber_no_digit.yaml
+++ b/analyser/rules_specifications/addr_housenumber_no_digit.yaml
@@ -31,8 +31,9 @@ QUERY:
                             relation_id: !variable osm_id
                     - address: !variable address
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/addr_place_and_street.yaml
+++ b/analyser/rules_specifications/addr_place_and_street.yaml
@@ -26,8 +26,9 @@ QUERY:
                         relation_id: !variable osm_id
                 - address: !variable address
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/addr_place_or_street_rank28.yaml
+++ b/analyser/rules_specifications/addr_place_or_street_rank28.yaml
@@ -26,8 +26,9 @@ QUERY:
                         relation_id: !variable osm_id
                 - address: !variable address
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/addr_street_wrong_name.yaml
+++ b/analyser/rules_specifications/addr_street_wrong_name.yaml
@@ -31,8 +31,9 @@ QUERY:
                 - street_name: !variable street_name
                 - parent_name: !variable parent_name
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/place_nodes_close.yaml
+++ b/analyser/rules_specifications/place_nodes_close.yaml
@@ -18,8 +18,9 @@ QUERY:
             FEATURE_CONVERTER:
               type: PlaceNodesCloseCustomFeatureConverter
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/analyser/rules_specifications/same_wikidata.yaml
+++ b/analyser/rules_specifications/same_wikidata.yaml
@@ -9,8 +9,9 @@ QUERY:
     CONVERTER:
       type: SameWikiDataFeatureConverter
       out:
-        VECTOR_TILES:
-          type: VectorTileFormatter
+        ClUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
           out:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter

--- a/clustering-vt/clustering-vt.cpp
+++ b/clustering-vt/clustering-vt.cpp
@@ -16,6 +16,8 @@
 #include <iterator>
 #include <filesystem>
 
+const int maxZoom = 13;
+
 struct properties_to_point_feature_builder {
     vtzero::point_feature_builder& featureBuilder;
     std::string key = "";
@@ -69,7 +71,87 @@ void write_data_to_file(const std::string& buffer, const std::string& filename) 
     stream.close();
 }
 
-const int maxZoom = 11;
+/**
+ * Recursively generates all tiles.
+ * 
+ * The firstTileX and firstTileY parameters are the coordinates of
+ * the top left tile of the group of subtiles that we want to generate. 
+ * See https://docs.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system
+ * 
+ * For each of the four tiles of the group, if a tile contains features and contains at least
+ * one cluster, all its child tiles (four tiles again) are generated for the next zoom level 
+ * by the same function recursively.
+ * 
+ * The recursion stop when we read the max zoom level + 1 or if there is no tiles left to generate because
+ * there are no clusters left.
+ */
+void generate_tiles(const short zoom, 
+                    const int firstTileX, 
+                    const int firstTileY, 
+                    const std::string& outputFolder, 
+                    mapbox::supercluster::Supercluster superclusterIndex) {
+    for (int x = firstTileX; x < firstTileX + 2; x++) {
+        for (int y = firstTileY; y < firstTileY + 2; y++) {
+            mapbox::feature::feature_collection<std::int16_t> tile = superclusterIndex.getTile(zoom, x, y);
+
+            if (tile.size() != 0) {
+                vtzero::tile_builder tileBuilder;
+                vtzero::layer_builder layerBuilder{tileBuilder, "clustersLayer", 1, 256};
+                vtzero::key_index<std::unordered_map> idx{layerBuilder};
+
+                bool hasCluster = false;
+
+                for (auto &f : tile) {
+                    const mapbox::geometry::point<std::int16_t> featurePoint = f.geometry.get<mapbox::geometry::point<std::int16_t>>();
+
+                    {
+                        vtzero::point_feature_builder featureBuilder{layerBuilder};
+                        featureBuilder.add_point(featurePoint.x, featurePoint.y);
+                        properties_to_point_feature_builder {featureBuilder}(f.properties);
+
+                        //Add the clusterExpansionZoom to a property if the feature is a cluster.
+                        const auto iterator = f.properties.find("cluster_id");
+                        if (iterator != f.properties.end() && iterator->second.get<uint64_t>()) {
+                            hasCluster = true;
+                            uint8_t expansionZoom = superclusterIndex.getClusterExpansionZoom(f.properties["cluster_id"].get<uint64_t>());
+                            featureBuilder.add_property("clusterExpansionZoom", expansionZoom);
+                        }
+
+                        featureBuilder.commit();
+                    }
+                }
+
+                const auto data = tileBuilder.serialize();
+
+                std::ostringstream folderPath;
+                folderPath << outputFolder << "/" << zoom << "/" << x;
+
+                std::ostringstream pbfPath;
+                pbfPath << outputFolder << "/" << zoom << "/" << x << "/" << y << ".pbf";
+
+                std::filesystem::create_directories(folderPath.str());
+                write_data_to_file(data, pbfPath.str());
+
+                //If there is features and clusters inside the tile, we need to also generate its child tiles.
+                //Generate until maxZoom + 1 to also add features where there is no clusters left.
+                if (hasCluster && zoom + 1 <= maxZoom + 1) {
+                    generate_tiles(
+                        zoom + 1,
+                        2*x, //To understand how we get the subtiles coordinates, check the "subtiles" section: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+                        2*y,  //We only call the generate_tiles for the subtile in the top left corner of the four subtiles.
+                        outputFolder,
+                        superclusterIndex
+                    );
+                }
+            }
+
+            //At zoom level = 0 there is only 1 one tile, so we should return after it has been generated.
+            if (zoom == 0 && firstTileX == 0 && firstTileY == 0) {
+                return;
+            }
+        }
+    }
+}
 
 int main(int argc, char *argv[]) {
     if (argc == 1) {
@@ -113,51 +195,7 @@ int main(int argc, char *argv[]) {
 
         timer("total supercluster time");
 
-        for (int z = 0; z <= maxZoom + 1; z++) {
-            const int zoomDimension = std::pow(2, z);
-            for (int x = 0; x < zoomDimension; x++) {
-                for (int y = 0; y < zoomDimension; y++) {
-                    
-                    mapbox::feature::feature_collection<std::int16_t> tile = index.getTile(z, x, y);
-
-                    if (tile.size() != 0) {
-                        vtzero::tile_builder tileBuilder;
-                        vtzero::layer_builder layerBuilder{tileBuilder, "clustersLayer", 1, 256};
-                        vtzero::key_index<std::unordered_map> idx{layerBuilder};
-
-                        for (auto &f : tile) {
-                            const mapbox::geometry::point<std::int16_t> featurePoint = f.geometry.get<mapbox::geometry::point<std::int16_t>>();
-
-                            {
-                                vtzero::point_feature_builder featureBuilder{layerBuilder};
-                                featureBuilder.add_point(featurePoint.x, featurePoint.y);
-                                properties_to_point_feature_builder {featureBuilder}(f.properties);
-
-                                //Add the clusterExpansionZoom to a property if the feature is a cluster.
-                                const auto iterator = f.properties.find("cluster_id");
-                                if (iterator != f.properties.end() && iterator->second.get<uint64_t>()) {
-                                    uint8_t expansionZoom = index.getClusterExpansionZoom(f.properties["cluster_id"].get<uint64_t>());
-                                    featureBuilder.add_property("clusterExpansionZoom", expansionZoom);
-                                }
-
-                                featureBuilder.commit();
-                            }
-                        }
-
-                        const auto data = tileBuilder.serialize();
-
-                        std::ostringstream folderPath;
-                        folderPath << argv[1] << "/" << z << "/" << x;
-
-                        std::ostringstream pbfPath;
-                        pbfPath << argv[1] << "/" << z << "/" << x << "/" << y << ".pbf";
-
-                        std::filesystem::create_directories(folderPath.str());
-                        write_data_to_file(data, pbfPath.str());
-                    }
-                }
-            }
-        }
+        generate_tiles(0, 0, 0, argv[1], index);
 
         timer("total tiles generation time");
     }else {


### PR DESCRIPTION
Fixes #9 

The generation of vector tiles by clustering-vt has been greatly optimized. Instead of iterating over 2^zoom * 2^zoom for each zoom level (which was increasing exponentially) the algorithm now generates the tiles recursively.

For each tile, if Supercluster generated features for it and if there is at least one cluster, we generate the four sub-tiles of this tile by calling the same function recursively:

![sub-tiles](https://user-images.githubusercontent.com/14927966/130840728-6adb1cf9-46bc-4fdd-936b-a4f39a66be06.png)

By generating the tiles recursively like that, we can easily stop the zoom descent for a specific tile if it contains no features or no clusters (if there is no clusters we just need to generate the features as they are, only once). This greatly reduce the amount of operations, for example: 

If we have a max zoom + 1 of 12, stopping one tile at zoom level 2 will prevent the processing of 4^10 = 1048576 tiles.

This allows us to now have a max zoom of 13 for clustering-vt, we could easily set an higher number but we don't want to generate clusters to far. The global tiles generation duration has been greatly reduced.