### PR TITLE
Optimized vector tiles generation by switching to recursion

### DIFF
--- a/clustering-vt/clustering-vt.cpp
+++ b/clustering-vt/clustering-vt.cpp
@@ -89,7 +89,7 @@ void generate_tiles(const short zoom,
                     const int firstTileX, 
                     const int firstTileY, 
                     const std::string& outputFolder, 
-                    mapbox::supercluster::Supercluster superclusterIndex) {
+                    mapbox::supercluster::Supercluster& superclusterIndex) {
     for (int x = firstTileX; x < firstTileX + 2; x++) {
         for (int y = firstTileY; y < firstTileY + 2; y++) {
             mapbox::feature::feature_collection<std::int16_t> tile = superclusterIndex.getTile(zoom, x, y);


### PR DESCRIPTION
Fixes #9 

The generation of vector tiles by clustering-vt has been greatly optimized. Instead of iterating over 2^zoom * 2^zoom for each zoom level (which was increasing exponentially) the algorithm now generates the tiles recursively with a divide-and-conquer algorithm.

For each tile, if Supercluster generated features for it and if there is at least one cluster, we generate the four sub-tiles of this tile by calling the same function recursively:

![sub-tiles](https://user-images.githubusercontent.com/14927966/130840728-6adb1cf9-46bc-4fdd-936b-a4f39a66be06.png)

By generating the tiles recursively like that, we can easily stop the zoom descent for a specific tile if it contains no features or no clusters (if there is no clusters we just need to generate the features as they are, only once). This greatly reduce the amount of operations, for example: 

If we have a max zoom + 1 of 12, stopping one tile at zoom level 2 will prevent the processing of 4^10 = 1048576 tiles.

This allows us to now have a max zoom of 13 for clustering-vt, we could easily set an higher number but we don't want to generate clusters to far. The global tiles generation duration has been greatly reduced.