### PR TITLE
More rule improvements

### DIFF
--- a/analyser/rules_specifications/addr_place_or_street_rank28.yaml
+++ b/analyser/rules_specifications/addr_place_or_street_rank28.yaml
@@ -4,8 +4,9 @@ QUERY:
   query: >
     SELECT ST_AsText(centroid) AS geometry_holder, osm_id, osm_type, address, class, type
     FROM placex p WHERE (address ? 'street' or address ? 'place')
-                  AND rank_address < 28
+                  AND rank_search < 28
                   AND NOT (class in ('landuse')
+                           OR type in ('postcode', 'houses')
                            OR (country_code in ('ca', 'us') and class = 'leisure' and type = 'park'))
                            AND NOT EXISTS (SELECT * FROM placex o
                                            WHERE o.osm_id = p.osm_id and o.osm_type = p.osm_type and rank_address = 30);

--- a/analyser/rules_specifications/addr_street_wrong_name.yaml
+++ b/analyser/rules_specifications/addr_street_wrong_name.yaml
@@ -7,7 +7,7 @@ QUERY:
     SELECT * FROM placex WHERE rank_address=30 AND address ? 'street'
     ) AS px1 INNER JOIN placex AS px2 
     ON px1.parent_place_id = px2.place_id 
-    WHERE px1.address->'street' != px2.name->'name';
+    WHERE not px1.address->'street' = any(avals(px2.name));
   out:
     LOOP_PROCESSING:
       type: LoopDataProcessor
@@ -41,5 +41,10 @@ QUERY:
               name: addr:street wrong name
               updates: Every evening
               doc:
-                description: addr:street without a street with the same name.
-                how_to_fix: The street should have a valid name.
+                description: The addr:street tag does not match the name of the street the address was assigned to.
+                why_problem: The addr:street tag should have exactly the same name as the street.
+                how_to_fix: |
+                  Check if there is a typo in the addr:street tag or
+                  in the name of the street. Another possible cause for this
+                  error: the address is part of an associatedStreet relation
+                  that has an error.


### PR DESCRIPTION
* Reintroduce the postcode filter for the rank28 rule, it got accidentally lost.
* be a bit more lenient with the name matching in the wrong street rule and allow translated names
* improve description of wrong street name rule