### PR TITLE
Set unique id to each rule layer

### DIFF
--- a/analyser/core/pipes/output_formatters/osmoscope_layer_formatter.py
+++ b/analyser/core/pipes/output_formatters/osmoscope_layer_formatter.py
@@ -12,7 +12,7 @@ class OsmoscopeLayerFormatter(Pipe):
         self.base_folder_path = Path(f'{Config.values["RulesFolderPath"]}/{self.exec_context.rule_name}/osmoscope-layer')
         self.file_name = self.extract_data('file_name', 'layer')
         self.data_format_url = self.extract_data('data_format_url', required=True)
-        self.data['id'] = 'SuspectsData'
+        self.data['id'] = self.extract_data('id', default=self.exec_context.rule_name)
 
     def process(self, data_source_path: str) -> None:
         """

--- a/docs/Pipes.md
+++ b/docs/Pipes.md
@@ -194,6 +194,7 @@ Generates a `Layer` file following the [Layer specification](https://github.com/
 
 **Optional fields**:
 
+* `id` -> Id of the layer, should be only composed of [a-z0-9_] and it should be unique among all the rules. Default value if not provided is the name of the YAML file of this rule.
 * `file_name` -> The file name for the generated file.
 * `updates` -> When are the data updated.
 * `doc` -> Dictionnary containing documentation of the layer:


### PR DESCRIPTION
Set the id value of the osmoscope layer file to an unique value for each rule.  The id value can be set in the YAML specification manually, otherwise the default value used is the name of the YAML file of the rule.