### PR TITLE
Tiles deletion optimization

### DIFF
--- a/analyser/core/pipes/output_formatters/clusters_vt_formatter.py
+++ b/analyser/core/pipes/output_formatters/clusters_vt_formatter.py
@@ -26,12 +26,7 @@ class ClustersVtFormatter(Pipe):
             The outputfolder is initially deleted if it exists.
         """
         feature_collection = FeatureCollection(features)
-        self.base_folder_path.mkdir(parents=True, exist_ok=True)
         timer = Timer().start_timer()
-
-        #Remove the output_dir with its content if it exists.
-        if self.base_folder_path.exists() and self.base_folder_path.is_dir():
-            shutil.rmtree(self.base_folder_path)
 
         self.call_clustering_vt(self.base_folder_path, feature_collection)
 

--- a/analyser/core/pipes/output_formatters/clusters_vt_formatter.py
+++ b/analyser/core/pipes/output_formatters/clusters_vt_formatter.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import List
 import subprocess
 import logging
-import shutil
 
 class ClustersVtFormatter(Pipe):
     """
@@ -45,10 +44,9 @@ class ClustersVtFormatter(Pipe):
             result = subprocess.run(
                 [f'{Path(__file__).parent.resolve()}/../../../../clustering-vt/build/clustering-vt', output_dir, str(self.radius)],
                 check=True,
-                input=dumps(feature_collection).encode(),
+                input=dumps(feature_collection, sort_keys=True).encode(),
                 capture_output=True
             )
-            print(result.stdout)
             self.log(result)
         except subprocess.TimeoutExpired as e:
             self.log(e, logging.FATAL)

--- a/clustering-vt/clustering-vt.cpp
+++ b/clustering-vt/clustering-vt.cpp
@@ -68,7 +68,6 @@ void write_data_to_file(const std::string& buffer, const std::string& filename) 
     }
 
     stream.exceptions(std::ifstream::failbit);
-
     stream.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
 
     stream.close();
@@ -185,7 +184,7 @@ void generate_tiles(const short zoom,
                             outputFolder,
                             superclusterIndex
                         );
-                    }else {      
+                    }else {
                         shouldDeleteChildTiles = true;
                     }
                 }

--- a/clustering-vt/clustering-vt.cpp
+++ b/clustering-vt/clustering-vt.cpp
@@ -18,6 +18,9 @@
 
 const int maxZoom = 13;
 
+int amountRemoved = 0;
+int amountCreated = 0;
+
 struct properties_to_point_feature_builder {
     vtzero::point_feature_builder& featureBuilder;
     std::string key = "";
@@ -71,6 +74,46 @@ void write_data_to_file(const std::string& buffer, const std::string& filename) 
     stream.close();
 }
 
+bool try_delete_tile(const std::string& pbfPath) {
+    const bool removed = std::filesystem::remove(pbfPath);
+    if (removed) {
+        amountRemoved++;
+    }
+    return removed;
+}
+
+std::string getTileFolderPath(const std::string& outputFolder, const short zoom, const int x) {
+    std::ostringstream folderPathStream;
+    folderPathStream << outputFolder << "/" << zoom << "/" << x;
+    return folderPathStream.str();
+}
+
+std::string getTilePbfPath(const std::string& outputFolder, const short zoom, const int x, const int y) {
+    std::ostringstream pbfPathStream;
+    pbfPathStream << outputFolder << "/" << zoom << "/" << x << "/" << y << ".pbf";
+    return pbfPathStream.str();
+}
+
+void delete_sub_tiles(const short zoom, 
+                      const int firstTileX, 
+                      const int firstTileY, 
+                      const std::string& outputFolder) {
+    for (int x = firstTileX; x < firstTileX + 2; x++) {
+        for (int y = firstTileY; y < firstTileY + 2; y++) {
+            const std::string pbfPath = getTilePbfPath(outputFolder, zoom, x, y);
+
+            if (try_delete_tile(pbfPath) && zoom + 1 <= maxZoom + 1) {
+                delete_sub_tiles(
+                    zoom + 1,
+                    2*x, //To understand how we get the subtiles coordinates, check the "subtiles" section: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+                    2*y,  //We only call the generate_tiles for the subtile in the top left corner of the four subtiles.
+                    outputFolder
+                );
+            }
+        }
+    }
+}
+
 /**
  * Recursively generates all tiles.
  * 
@@ -93,6 +136,12 @@ void generate_tiles(const short zoom,
     for (int x = firstTileX; x < firstTileX + 2; x++) {
         for (int y = firstTileY; y < firstTileY + 2; y++) {
             mapbox::feature::feature_collection<std::int16_t> tile = superclusterIndex.getTile(zoom, x, y);
+            
+            bool shouldDeleteChildTiles = false;
+
+            const std::string folderPath = getTileFolderPath(outputFolder, zoom, x);
+            const std::string pbfPath = getTilePbfPath(outputFolder, zoom, x, y);
+
             if (tile.size() != 0) {
                 vtzero::tile_builder tileBuilder;
                 vtzero::layer_builder layerBuilder{tileBuilder, "clustersLayer", 1, 256};
@@ -102,7 +151,6 @@ void generate_tiles(const short zoom,
 
                 for (auto &f : tile) {
                     const mapbox::geometry::point<std::int16_t> featurePoint = f.geometry.get<mapbox::geometry::point<std::int16_t>>();
-
                     {
                         vtzero::point_feature_builder featureBuilder{layerBuilder};
                         featureBuilder.add_point(featurePoint.x, featurePoint.y);
@@ -122,26 +170,38 @@ void generate_tiles(const short zoom,
 
                 const auto data = tileBuilder.serialize();
 
-                std::ostringstream folderPath;
-                folderPath << outputFolder << "/" << zoom << "/" << x;
-
-                std::ostringstream pbfPath;
-                pbfPath << outputFolder << "/" << zoom << "/" << x << "/" << y << ".pbf";
-
-                std::filesystem::create_directories(folderPath.str());
-                write_data_to_file(data, pbfPath.str());
+                std::filesystem::create_directories(folderPath);
+                write_data_to_file(data, pbfPath);
+                amountCreated++;
 
                 //If there is features and clusters inside the tile, we need to also generate its child tiles.
                 //Generate until maxZoom + 1 to also add features where there is no clusters left.
-                if (hasCluster && zoom + 1 <= maxZoom + 1) {
-                    generate_tiles(
-                        zoom + 1,
-                        2*x, //To understand how we get the subtiles coordinates, check the "subtiles" section: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
-                        2*y,  //We only call the generate_tiles for the subtile in the top left corner of the four subtiles.
-                        outputFolder,
-                        superclusterIndex
-                    );
+                if (zoom + 1 <= maxZoom + 1) {
+                    if (hasCluster) {
+                        generate_tiles(
+                            zoom + 1,
+                            2*x, //To understand how we get the subtiles coordinates, check the "subtiles" section: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+                            2*y,  //We only call the generate_tiles for the subtile in the top left corner of the four subtiles.
+                            outputFolder,
+                            superclusterIndex
+                        );
+                    }else {      
+                        shouldDeleteChildTiles = true;
+                    }
                 }
+            }else {
+                if (try_delete_tile(pbfPath) && zoom + 1 <= maxZoom + 1) {
+                    shouldDeleteChildTiles = true;
+                }
+            }
+
+            if (shouldDeleteChildTiles) {
+                delete_sub_tiles(
+                    zoom + 1,
+                    2*x, //To understand how we get the subtiles coordinates, check the "subtiles" section: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+                    2*y,  //We only call the generate_tiles for the subtile in the top left corner of the four subtiles.
+                    outputFolder
+                );
             }
 
             //At zoom level = 0 there is only 1 one tile, so we should return after it has been generated.
@@ -197,6 +257,8 @@ int main(int argc, char *argv[]) {
         generate_tiles(0, 0, 0, argv[1], index);
 
         timer("total tiles generation time");
+        std::cout << "Tiles created: " << amountCreated << "\n";
+        std::cout << "Tiles removed: " << amountRemoved << "\n";
     }else {
         std::cerr << "GeoJSON is needed in stdin!\n";
         return 1;


### PR DESCRIPTION
Fixes #10 

The whole vector tiles folder of a rule is not completely deleted anymore before generating the new vector tiles. Instead the PBF file corresponding to a tile which does not exist anymore is deleted automatically by the clustering-vt module while generating the tiles. All its child tiles are also deleted recursively if they exist.

One problem is that the SQL queries of the analyser does not return the elements in the same order each time and supercluster does not generate the exact same tiles if the input features are not in the same order as the last time. For most of the rules there is no problems with that, however for the biggest rules like "addr street wrong name" with millions of results, it seems that clustering-vt is deleting like 400 tiles out of 97K generated every time it runs because it might generate the tiles differently than the last time. This is still way better than deleting all the tiles each time.

However, this means that we can't read the tiles to check if they should be overriden (because the content will not be the same as explained before). Applying an ORDER BY on the rules does not seem a good option as it will increase the rules execution time in a significant way. 

Do you think that we can stay with this tiles deletion optimization @lonvia?