### PR TITLE
Timestamp to the log output and better log message format

### DIFF
--- a/analyser/core/assembler/pipeline_assembler.py
+++ b/analyser/core/assembler/pipeline_assembler.py
@@ -37,7 +37,7 @@ class PipelineAssembler():
             pipe = PipeFactory.assemble_pipe(node, self.exec_context)
             #Plug the new pipe to the current last pipe of the deque
             self.nodes_history[-1].plug_pipe(pipe)
-            LOG.info("Rule <%s> : Assembler -> %s plugged to %s", self.rule_name, pipe, self.nodes_history[-1])
+            LOG.info("<%s> Assembler -> %s plugged to %s", self.rule_name, pipe, self.nodes_history[-1])
             self.nodes_history.append(pipe)
 
     def on_backtrack(self) -> None:

--- a/analyser/core/core.py
+++ b/analyser/core/core.py
@@ -32,4 +32,4 @@ class Core():
         timer = Timer().start_timer()
         loaded_yaml: Dict = load_yaml_rule(name)
         PipelineAssembler(loaded_yaml, name).assemble().process_and_next()
-        LOG.info('Rule <%s> : The whole rule executed in %s mins %s secs', name, *timer.get_elapsed())
+        LOG.info('<%s> The whole rule executed in %s mins %s secs', name, *timer.get_elapsed())

--- a/analyser/core/deconstructor/pipeline_deconstructor.py
+++ b/analyser/core/deconstructor/pipeline_deconstructor.py
@@ -84,7 +84,7 @@ class PipelineDeconstructor():
         """
             Notifies all subscribers that we reached a new node.
         """
-        LOG.info('Rule <%s> : Deconstruction -> NEW_NODE %s', self.rule_name, node['type'])
+        LOG.info('<%s> Deconstruction -> NEW_NODE %s', self.rule_name, node['type'])
         self._raise_event(NEW_NODE_EVENT, node)
 
     def _notify_backtracking(self,) -> None:
@@ -92,7 +92,7 @@ class PipelineDeconstructor():
             Notifies all subscribers that we are backtracking because
             the deconstructor reached a leaf.
         """
-        LOG.info('Rule <%s> : Deconstruction -> BACKTRACK', self.rule_name)
+        LOG.info('<%s> Deconstruction -> BACKTRACK', self.rule_name)
         self._raise_event(BACKTRACKING_EVENT)
     
     def _raise_event(self, event_name: str, *args: any) -> None:

--- a/analyser/core/pipe.py
+++ b/analyser/core/pipe.py
@@ -81,4 +81,4 @@ class Pipe(metaclass=ABCMeta):
             Log the given message with the given log level (default is INFO).
             The rule name is automatically prefixed to the log message.
         """
-        LOG.log(level, f'Rule <{self.exec_context.rule_name}> : {msg}')
+        LOG.log(level, f'<{self.exec_context.rule_name}> {msg}')

--- a/analyser/logger/logger.py
+++ b/analyser/logger/logger.py
@@ -1,5 +1,6 @@
 import logging
 
-logging.basicConfig()
+logging.basicConfig(format='%(asctime)s: %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)


### PR DESCRIPTION
Fixes #4 

Added the timestamp to the log output format and cleared a bit the format of the log messages for the rule execution.