### PR TITLE
Allow address tags on parks everywhere

### DIFF
--- a/analyser/rules_specifications/addr_place_or_street_rank28.yaml
+++ b/analyser/rules_specifications/addr_place_or_street_rank28.yaml
@@ -7,7 +7,7 @@ QUERY:
                   AND rank_search < 28
                   AND NOT (class in ('landuse')
                            OR type in ('postcode', 'houses')
-                           OR (country_code in ('ca', 'us') and class = 'leisure' and type = 'park'))
+                           OR (class = 'leisure' and type = 'park'))
                            AND NOT EXISTS (SELECT * FROM placex o
                                            WHERE o.osm_id = p.osm_id and o.osm_type = p.osm_type and rank_address = 30);
   out:


### PR DESCRIPTION
Looks like address tagging on park is a frequent thing everywhere in the world, so exclude them completely from the addr_place_or_street_rank28 check.