### PR TITLE
[WIP] remove null values before creating vector tiles

### DIFF
--- a/src/nominatim_data_analyser/core/pipes/output_formatters/geojson_formatter.py
+++ b/src/nominatim_data_analyser/core/pipes/output_formatters/geojson_formatter.py
@@ -20,6 +20,14 @@ class GeoJSONFormatter(Pipe):
             Create the FeatureCollection and dump it to
             a new GeoJSON file.
         """
+
+        # tippecanoe (using sqlite as datastore) converts Null to 0.
+        # https://github.com/mapbox/tippecanoe/issues/811
+        # Thus loop through all features and remove any properties having Null values.
+        if features is not None:
+            for feature in features:
+                feature['properties'] = {k: v for k, v in feature['properties'].items() if v is not None}
+
         feature_collection = FeatureCollection(features)
         self.base_folder_path.mkdir(parents=True, exist_ok=True)
         full_path = self.base_folder_path / f'{self.file_name}.json'

--- a/src/nominatim_data_analyser/core/pipes/output_formatters/vector_tile_formatter.py
+++ b/src/nominatim_data_analyser/core/pipes/output_formatters/vector_tile_formatter.py
@@ -21,6 +21,14 @@ class VectorTileFormatter(Pipe):
             Converts a list of features to vector tiles by
             calling tippecanoe from the command line.
         """
+
+        # tippecanoe (using sqlite as datastore) converts Null to 0.
+        # https://github.com/mapbox/tippecanoe/issues/811
+        # Thus loop through all features and remove any properties having Null values.
+        if features is not None:
+            for feature in features:
+                feature['properties'] = {k: v for k, v in feature['properties'].items() if v is not None}
+
         feature_collection = FeatureCollection(features)
         self.base_folder_path.mkdir(parents=True, exist_ok=True)
         timer = Timer().start_timer()

--- a/tests/pipes/output_formatters/test_geojson_formatter.py
+++ b/tests/pipes/output_formatters/test_geojson_formatter.py
@@ -17,7 +17,7 @@ def test_process_geojson_formatter(config: Config,
     geojson_formatter.base_folder_path = tmp_path / 'test_folder'
 
     features = [
-        Feature(geometry=Point((5, 2))),
+        Feature(geometry=Point((5, 2)), properties={'key': 'value', 'null': None}),
         Feature(geometry=Point((4, 1))),
         Feature(geometry=Point((10, 20)))
     ]
@@ -27,4 +27,8 @@ def test_process_geojson_formatter(config: Config,
 
     #Verify the content of the geojson created
     with open(tmp_path/'test_folder/test_file.json' , 'r') as file:
-        assert loads(file.read()) == FeatureCollection(features)
+        data = loads(file.read())
+        assert data == FeatureCollection(features)
+        # Make sure empty values got removed
+        assert FeatureCollection(data)['features'][0]['properties'] == {'key': 'value'}
+        assert FeatureCollection(data)['features'][1]['properties'] == {}

--- a/tests/pipes/output_formatters/test_vector_tile_formatter.py
+++ b/tests/pipes/output_formatters/test_vector_tile_formatter.py
@@ -20,7 +20,7 @@ def test_process_vector_tile_formatter(vector_tile_formatter: VectorTileFormatte
     vector_tile_formatter.base_folder_path = tmp_path / 'test_folder'
 
     features = [
-        Feature(geometry=Point((5, 2))),
+        Feature(geometry=Point((5, 2)), properties={'key': 'value', 'null': None}),
         Feature(geometry=Point((4, 1))),
         Feature(geometry=Point((10, 20)))
     ]


### PR DESCRIPTION
Didn't actually get it working yet. The vector tiles still contain '0' values. Currently the tests don't execute tippecanoe so needs more manual debugging.

Related "Null property values become 0?" https://github.com/mapbox/tippecanoe/issues/811