### PR TITLE
Fix rule names case

### DIFF
--- a/docs/YAML-Rule-Specification.md
+++ b/docs/YAML-Rule-Specification.md
@@ -34,7 +34,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: geojson_url
-              name: no admin level
+              name: No admin level
               updates: Every evening
               doc:
                 description: Every relation with boundary=administrative should have an admin_level value set.
@@ -172,7 +172,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: geojson_url
-              name: no admin level
+              name: No admin level
               updates: Every evening
               doc:
                 description: Every relation with boundary=administrative should have an admin_level value set.

--- a/src/nominatim_data_analyser/rules_specifications/BA_way_not_part_relation.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/BA_way_not_part_relation.yaml
@@ -27,7 +27,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: vector_tile_url
-              name: boundary ways without relation
+              name: Boundary ways without relation
               updates: Every evening
               doc:
                 description: Ways with boundary=administrative that are not part of a relation.

--- a/src/nominatim_data_analyser/rules_specifications/duplicate_label_role.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/duplicate_label_role.yaml
@@ -22,7 +22,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: geojson_url
-              name: duplicate label role
+              name: Duplicate label role
               updates: Every evening
               doc:
                 description: Admin boundaries with more than one member with role 'label'.

--- a/src/nominatim_data_analyser/rules_specifications/no_admin_level.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/no_admin_level.yaml
@@ -23,7 +23,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: geojson_url
-              name: no admin level
+              name: No admin level
               updates: Every evening
               doc:
                 description: Every relation with boundary=administrative should have an admin_level value set.

--- a/src/nominatim_data_analyser/rules_specifications/place_nodes_close.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/place_nodes_close.yaml
@@ -25,7 +25,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: vector_tile_url
-              name: place nodes close
+              name: Place nodes close
               updates: Every evening
               doc:
                 description: Place nodes of same type and name close to each other.

--- a/src/nominatim_data_analyser/rules_specifications/postcode_bad_format.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/postcode_bad_format.yaml
@@ -205,7 +205,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: vector_tile_url
-              name: Unusual Postcode Format
+              name: Unusual postcode format
               update: Every evening
               doc:
                 description: |

--- a/src/nominatim_data_analyser/rules_specifications/same_wikidata.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/same_wikidata.yaml
@@ -17,7 +17,7 @@ QUERY:
             LAYER_FILE:
               type: OsmoscopeLayerFormatter
               data_format_url: vector_tile_url
-              name: duplicate wikidata id
+              name: Duplicate wikidata ID
               updates: Every evening
               doc:
                 description: A single wikidata id should be assigned to at most one place node.


### PR DESCRIPTION
Currently, some rule names are in sentence case (1), others are in lowercase (2), while yet others are in title case (3):

<img width="351" height="685" alt="image" src="https://github.com/user-attachments/assets/a5d08c2e-e4b0-4f8c-96c8-edc82e080151" />

I thought it might be nice to standardise them all to sentence case.