### PR TITLE
Some countries have no agreement if addr:state or addr:province is used

### DIFF
--- a/src/nominatim_data_analyser/rules_specifications/addr_state_not_country.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/addr_state_not_country.yaml
@@ -18,9 +18,15 @@ QUERY:
       (
         LOWER(address->'state') = placex.country_code
         OR
-        LOWER(address->'state') = LOWER(address->'province')
+        (
+          LOWER(address->'state') = LOWER(address->'province')
+          AND placex.country_code NOT IN ('ar', 'bd', 'bz')
+        )
         OR
-        LOWER(address->'state') = ANY(country_names.names_array)
+        (
+          LOWER(address->'state') = ANY(country_names.names_array)
+          AND placex.country_code NOT IN ('mx')
+        )
       );
   out:
     LOOP_PROCESSING:


### PR DESCRIPTION
Excceptions for the addr_state_not_country rules:

* Mexico has a state called Mexico
* In Argentina, Algeria, Bangladesh both addr:state and addr:province are used equally. In Bangladesh for example the country is divided into 8 divisions (https://en.wikipedia.org/wiki/Divisions_of_Bangladesh)