### PR TITLE
new rule: nat_name_not_country

### DIFF
--- a/src/nominatim_data_analyser/rules_specifications/nat_name_not_country.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/nat_name_not_country.yaml
@@ -1,0 +1,56 @@
+---
+QUERY:
+  type: SQLProcessor
+  query: >
+    WITH country_names AS MATERIALIZED (
+      SELECT
+        country_code,
+        ARRAY(
+          SELECT DISTINCT(LOWER(v)) FROM UNNEST(AVALS(derived_name)) as v
+        ) AS names_array
+      FROM country_name
+    )
+    SELECT ST_AsText(centroid) AS geometry_holder, osm_id, osm_type, name->'nat_name' as nat_name
+    FROM placex
+    JOIN country_names ON placex.country_code = country_names.country_code
+    WHERE
+      name ? 'nat_name' AND
+      not address ? '_inherited' AND
+      type != 'country' AND
+      admin_level != 2 AND
+      LOWER(name->'nat_name') = ANY(country_names.names_array);
+  out:
+    LOOP_PROCESSING:
+      type: LoopDataProcessor
+      sub_pipeline: !sub-pipeline
+        GEOMETRY_CONVERTER:
+          type: GeometryConverter
+          geometry_type: Node
+          out:
+            FEATURE_CONVERTER:
+              type: GeoJSONFeatureConverter
+              properties:
+                - !switch
+                    expression: osm_type
+                    cases:
+                      'N': 
+                        node_id: !variable osm_id
+                      'W': 
+                        way_id: !variable osm_id
+                      'R': 
+                        relation_id: !variable osm_id
+                - nat_name: !variable nat_name
+      out:
+        CLUSTERING_VECTOR_TILES:
+          type: ClustersVtFormatter
+          radius: 60
+          out:
+            LAYER_FILE:
+              type: OsmoscopeLayerFormatter
+              data_format_url: vector_tile_url
+              name: Suspicious nat_name value
+              updates: Every evening
+              doc:
+                description: nat_name contains the name of the country
+                why_problem: nat_name (national name) sometimes gets misunderstood as being the name of the nation (country).
+                how_to_fix: Check if the feature is really the country, nation or equivalent


### PR DESCRIPTION
I found 5 more OSM features that use nat_name=country name but aren't countries. It's fairly similar to addr_state_not_country but the documentation would start to be confusing between the two.

https://wiki.openstreetmap.org/wiki/Key:name just says "National name"

<img width="638" height="726" alt="image" src="https://github.com/user-attachments/assets/7975e3d3-02cf-471d-92b1-446f8d23fda4" />
<img width="662" height="476" alt="image" src="https://github.com/user-attachments/assets/f8922a91-b1c1-4d58-b01d-ab8bd1567576" />
