### PR TITLE
fix: skip flag for addr:street matching highway 

### DIFF
--- a/src/nominatim_data_analyser/core/pipes/rules_specific_pipes/addr_street_wrong_name/equal_street_name_filter.py
+++ b/src/nominatim_data_analyser/core/pipes/rules_specific_pipes/addr_street_wrong_name/equal_street_name_filter.py
@@ -7,17 +7,22 @@ class EqualStreetNameFilter(Pipe):
     def process(self, elements: dict[str, Any]) -> dict[str, Any] | None:
         addr_street = elements.get('street_name', None)
         names = elements.get('full_name_set', [])
-        if addr_street and len(names) > 1:
-            for key, val in names.items():
-                prefix_less = key.replace(':prefix', '')
-                if len(prefix_less) < len(key):
-                    if (stem := names.get(prefix_less, None)) is not None:
-                        if ' '.join((val, stem)) == addr_street:
-                            return None
-                suffix_less = key.replace(':suffix', '')
-                if len(suffix_less) < len(key):
-                    if (stem := names.get(suffix_less, None)) is not None:
-                        if ' '.join((stem, val)) == addr_street:
-                            return None
+        if addr_street and isinstance(names, dict):
+            if len(names) > 1:
+                for key, val in names.items():
+                    prefix_less = key.replace(':prefix', '')
+                    if len(prefix_less) < len(key):
+                        if (stem := names.get(prefix_less, None)) is not None:
+                            if ' '.join((val, stem)) == addr_street:
+                                return None
+                    suffix_less = key.replace(':suffix', '')
+                    if len(suffix_less) < len(key):
+                        if (stem := names.get(suffix_less, None)) is not None:
+                            if ' '.join((stem, val)) == addr_street:
+                                return None
+
+            parent_ref = names.get('ref', None)
+            if parent_ref and addr_street.endswith(' ' + parent_ref):
+                return None
 
         return elements

--- a/tests/pipes/rules_specific_pipes/addr_street_wrong_name/test_equal_street_name_filter.py
+++ b/tests/pipes/rules_specific_pipes/addr_street_wrong_name/test_equal_street_name_filter.py
@@ -1,0 +1,109 @@
+import pytest
+
+from nominatim_data_analyser.core.pipes import EqualStreetNameFilter
+from nominatim_data_analyser.core.qa_rule import ExecutionContext
+
+
+@pytest.fixture
+def equal_street_name_filter(
+        execution_context: ExecutionContext) -> EqualStreetNameFilter:
+    return EqualStreetNameFilter({}, execution_context)
+
+
+def test_matching_street_name_passes_through(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rua das Flores',
+        'full_name_set': {'name': 'Rua das Flores'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is not None
+
+
+def test_ref_based_naming_not_flagged(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rodovia BR-116',
+        'full_name_set': {'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is None
+
+
+def test_ref_based_naming_with_name_not_flagged(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rodovia BR-116',
+        'full_name_set': {'name': 'Rodovia Santos Dumont', 'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is None
+
+
+def test_ref_not_matching_passes_through(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rua das Flores',
+        'full_name_set': {'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is not None
+
+
+def test_ref_equal_to_street_passes_through(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'BR-116',
+        'full_name_set': {'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is not None
+
+
+def test_empty_full_name_set_passes_through(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rodovia BR-116',
+        'full_name_set': {}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is not None
+
+
+def test_prefix_plus_stem_filtered(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Rodovia BR-116',
+        'full_name_set': {'name:prefix': 'Rodovia', 'name': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is None
+
+
+def test_suffix_plus_stem_filtered(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'BR-116 Rodovia',
+        'full_name_set': {'name': 'BR-116', 'name:suffix': 'Rodovia'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is None
+
+
+def test_no_addr_street_returns_elements(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'full_name_set': {'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is not None
+
+
+def test_diff_prefix_ref_naming_not_flagged(
+        equal_street_name_filter: EqualStreetNameFilter):
+    data = {
+        'street_name': 'Avenida BR-116',
+        'full_name_set': {'ref': 'BR-116'}
+    }
+    result = equal_street_name_filter.process(data)
+    assert result is None


### PR DESCRIPTION
Closes https://github.com/osm-search/Nominatim/issues/4075 

## summary 

This PR addresses false positives in the addr_street_wrong_name QA rule for addresses alongside highways that use ref-based naming 
The EqualStreetNameFilter now checks if the parent road's name hstore contains a ref key and whether the addr:street value ends with " " followed by that ref. When this pattern matches, the address is recognized as following the standard highway addressing convention — common in Brazil and many other countries — and is no longer flagged as a mismatch.
The existing name:prefix/name:suffix logic is preserved unchanged. Comprehensive unit tests are added covering both the new ref-based matching and the existing prefix/suffix behavior.

## AI usage

LLM based CLI tools were used to explore the codebase, trace the data flow through SQL queries and Python pipes, and understand how ref values are stored in the placex.name hstore. All logic changes were manually implemented and verified.

## Contributor guidelines (mandatory)

- [x] I have adhered to the coding style
- [x] I have tested the proposed changes
- [x] I have disclosed above any use of AI to generate code, documentation, or the pull request description.