### PR TITLE
Accept street name matches against a highway ref in Brazil

### DIFF
--- a/src/nominatim_data_analyser/core/pipes/output_formatters/geojson_formatter.py
+++ b/src/nominatim_data_analyser/core/pipes/output_formatters/geojson_formatter.py
@@ -1,5 +1,5 @@
+from typing import Any
 from ....config import Config
-from typing import List
 from geojson.feature import Feature
 from ....core import Pipe
 from pathlib import Path
@@ -17,12 +17,16 @@ class GeoJSONFormatter(Pipe):
         # Take the rule's name as default file name.
         self.file_name = self.extract_data('file_name', self.exec_context.rule_name)
 
-    def process(self, features: List[Feature]) -> str:
+    def process(self, features: Any) -> str:
         """
             Create the FeatureCollection and dump it to
             a new GeoJSON file.
         """
-        feature_collection = FeatureCollection(features)
+        if isinstance(features, list):
+            feature_collection = FeatureCollection([f for f in features if isinstance(f, Feature)])
+        else:
+            feature_collection = FeatureCollection([])
+
         self.base_folder_path.mkdir(parents=True, exist_ok=True)
         full_path = self.base_folder_path / f'{self.file_name}.json'
 

--- a/src/nominatim_data_analyser/core/pipes/rules_specific_pipes/addr_street_wrong_name/equal_street_name_filter.py
+++ b/src/nominatim_data_analyser/core/pipes/rules_specific_pipes/addr_street_wrong_name/equal_street_name_filter.py
@@ -2,22 +2,50 @@ from typing import Any
 from ....pipe import Pipe
 
 
+def is_equal_with_affix(addr_street: str, names: dict[str, str]) -> bool:
+    """ Check if a combination of *:prefix or *:suffix with a name
+        returns a name that is equal to the street name.
+    """
+    if addr_street and len(names) > 1:
+        for key, val in names.items():
+            prefix_less = key.replace(':prefix', '')
+            if len(prefix_less) < len(key):
+                if (stem := names.get(prefix_less, None)) is not None:
+                    if ' '.join((val, stem)) == addr_street:
+                        return True
+            suffix_less = key.replace(':suffix', '')
+            if len(suffix_less) < len(key):
+                if (stem := names.get(suffix_less, None)) is not None:
+                    if ' '.join((stem, val)) == addr_street:
+                        return True
+
+    return False
+
+
+def is_brazilian_highway(cc: str, addr_street: str, names: dict[str, str]) -> bool:
+    """ If the address is in Brazil, check if the street name of
+        the address refers to a highway.
+    """
+    if cc == 'br':
+        ref = names.get('ref')
+        if ref and addr_street.startswith('Rodovia ') and addr_street[8:] == ref:
+            return True
+
+    return False
+
+
 class EqualStreetNameFilter(Pipe):
 
     def process(self, elements: dict[str, Any]) -> dict[str, Any] | None:
-        addr_street = elements.get('street_name', None)
-        names = elements.get('full_name_set', [])
-        if addr_street and len(names) > 1:
-            for key, val in names.items():
-                prefix_less = key.replace(':prefix', '')
-                if len(prefix_less) < len(key):
-                    if (stem := names.get(prefix_less, None)) is not None:
-                        if ' '.join((val, stem)) == addr_street:
-                            return None
-                suffix_less = key.replace(':suffix', '')
-                if len(suffix_less) < len(key):
-                    if (stem := names.get(suffix_less, None)) is not None:
-                        if ' '.join((stem, val)) == addr_street:
-                            return None
+        addr_street = elements.get('street_name', '')
+        names = elements.get('full_name_set', {})
+
+        if is_equal_with_affix(addr_street, names):
+            return None
+
+        cc = elements.get('country_code', '')
+
+        if is_brazilian_highway(cc, addr_street, names):
+            return None
 
         return elements

--- a/src/nominatim_data_analyser/rules_specifications/addr_street_wrong_name.yaml
+++ b/src/nominatim_data_analyser/rules_specifications/addr_street_wrong_name.yaml
@@ -4,7 +4,8 @@
     SELECT ST_AsText(px1.centroid) AS geometry_holder,
            px1.osm_id, px1.osm_type, px1.address->'street' as street_name,
            px2.name->'name' as parent_name,
-           px2.name as full_name_set
+           px2.name as full_name_set,
+           px1.country_code
     FROM (
     SELECT * FROM placex
       WHERE rank_address=30 AND address ? 'street' AND not address ? '_inherited'


### PR DESCRIPTION
This excludes addr:street vs. highway name mismatches for addresses in Brazil when the street name is equal to a `ref` tag with an additional 'Rodovia' prefix. Note that this is a bit less strict than what Nominatim allows: Nominatim only accepts refs of the form 'BR-XXX'.